### PR TITLE
Fix String Truncation if Python Byte objects contain NULL values

### DIFF
--- a/byte_array.go
+++ b/byte_array.go
@@ -52,7 +52,7 @@ func PyByteArray_Size(o *PyObject) int {
 
 //PyByteArray_AsString : https://docs.python.org/3/c-api/bytearray.html#c.PyByteArray_AsString
 func PyByteArray_AsString(o *PyObject) string {
-	return C.GoString(C.PyByteArray_AsString(toc(o)))
+	return C.GoStringN(C.PyByteArray_AsString(toc(o)), C.int(C.PyByteArray_Size(toc(o))))
 }
 
 //PyByteArray_Resize : https://docs.python.org/3/c-api/bytearray.html#c.PyByteArray_Resize

--- a/bytes.go
+++ b/bytes.go
@@ -47,7 +47,7 @@ func PyBytes_Size(o *PyObject) int {
 
 //PyBytes_AsString : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
 func PyBytes_AsString(o *PyObject) string {
-	return C.GoString(C.PyBytes_AsString(toc(o)))
+	return C.GoStringN(C.PyBytes_AsString(toc(o)), C.int(C.PyBytes_Size(toc(o)))) 
 }
 
 //PyBytes_Concat : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_Concat


### PR DESCRIPTION
### What does this PR do?

This fixes a truncation issue if a Python byte/bytearray contains null's which will cause C.GoString to truncate the data during conversion. This PR changes to use GoStringN with the size of the Byte/Bytearray object which will copy over everything.

For more info/motivation on the change https://utcc.utoronto.ca/~cks/space/blog/programming/GoCGoStringFunctions has a good writeup explaining the differences between GoString/GoStringN

### Motivation

What inspired you to submit this pull request? To fix a bug we encountered

### Additional Notes

Anything else we should know when reviewing? No

