### PR TITLE
Add PyBytes_FromStringAndSize to allow strings with NUL characters to be processed

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -35,6 +35,14 @@ func PyBytes_FromString(str string) *PyObject {
 	return togo(C.PyBytes_FromString(cstr))
 }
 
+//PyBytes_FromStringAndSize : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromStringAndSize
+func PyBytes_FromStringAndSize(str string) *PyObject {
+	cstr := C.CString(str)
+	defer C.free(unsafe.Pointer(cstr))
+
+	return togo(C.PyBytes_FromStringAndSize(cstr, C.Py_ssize_t(len(str))))
+}
+
 //PyBytes_FromObject : https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromObject
 func PyBytes_FromObject(o *PyObject) *PyObject {
 	return togo(C.PyBytes_FromObject(toc(o)))

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -35,6 +35,17 @@ func TestBytesFromAsString(t *testing.T) {
 	assert.Equal(t, s1, PyBytes_AsString(bytes1))
 }
 
+func TestBytesFromStringAndSize(t *testing.T) {
+	Py_Initialize()
+
+	s1 := "aaaaaaaa\x00bbbb"
+
+	bytes1 := PyBytes_FromStringAndSize(s1)
+	defer bytes1.DecRef()
+
+	assert.Equal(t, s1, PyBytes_AsString(bytes1))
+}
+
 func TestBytesSize(t *testing.T) {
 	Py_Initialize()
 


### PR DESCRIPTION

### What does this PR do?

It adds a wrapper function for `C.PyBytes_FromStringAndSize` that explicitly uses the Go string's length. This allows to correctly turn Go strings into Python `bytes` objects even when they contain NUL characters.

### Motivation

I wrote code that receives binary protobuf messages and hands them over to python code that in turn parses it into a python object and then processes the message. I noticed that when I used `python3.PyBytes_FromString` to turn the binary message into a python `bytes` object, it got truncated at NUL characters, which caused failures when decoding. Upon closer inspection, I noticed that this was inherent in how `PyBytes_FromString` worked, so I created this PR to fix this shortcoming.

### Additional Notes

None.
