### PR TITLE
Actually template the license

### DIFF
--- a/boolean.go
+++ b/boolean.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/byte_array.go
+++ b/byte_array.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/byte_array_test.go
+++ b/byte_array_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/bytes.go
+++ b/bytes.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/complex.go
+++ b/complex.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/complex_test.go
+++ b/complex_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/dict.go
+++ b/dict.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/dict_test.go
+++ b/dict_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/errors_nix.go
+++ b/errors_nix.go
@@ -1,5 +1,5 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
-// under $license_for_repo License.
+// under MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 

--- a/examples/list/main.go
+++ b/examples/list/main.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/examples/python3/main.go
+++ b/examples/python3/main.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/exceptions.go
+++ b/exceptions.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/float.go
+++ b/float.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/float_test.go
+++ b/float_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/helper.go
+++ b/helper.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/high_level_layer.go
+++ b/high_level_layer.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/import.go
+++ b/import.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/import_test.go
+++ b/import_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/integer.go
+++ b/integer.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/integer_test.go
+++ b/integer_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/list.go
+++ b/list.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/macro.c
+++ b/macro.c
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/macro.h
+++ b/macro.h
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/module.go
+++ b/module.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/object.go
+++ b/object.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/object_test.go
+++ b/object_test.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/recursion.go
+++ b/recursion.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/reflection.go
+++ b/reflection.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/script/variadic.go
+++ b/script/variadic.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */
@@ -31,7 +31,7 @@ func main() {
 	defer out.Close()
 	_, err = out.WriteString(`/*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/sys.go
+++ b/sys.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/thread.go
+++ b/thread.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/tuple.go
+++ b/tuple.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/type.go
+++ b/type.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/unicode.go
+++ b/unicode.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/variadic.c
+++ b/variadic.c
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/variadic.h
+++ b/variadic.h
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */

--- a/warning.go
+++ b/warning.go
@@ -1,6 +1,6 @@
 /*
 Unless explicitly stated otherwise all files in this repository are licensed
-under the $license_for_repo License.
+under the MIT License.
 This product includes software developed at Datadog (https://www.datadoghq.com/).
 Copyright 2018 Datadog, Inc.
 */


### PR DESCRIPTION
I'm pretty sure the `$license_for_repo` is a placeholder 🤣 .

### What does this PR do?

Fix the license template headers.

### Motivation

Was going through the https://datadoghq.atlassian.net/wiki/spaces/OS/pages/1761083447/Datadog+Open+Source+Policy and looking for examples and noticed this repo was incorrect.
