### PR TITLE
fix Py_EnterRecursiveCall C.free sequence

### DIFF
--- a/recursion.go
+++ b/recursion.go
@@ -20,7 +20,7 @@ import (
 //Py_EnterRecursiveCall : https://docs.python.org/3/c-api/exceptions.html#c.Py_EnterRecursiveCall
 func Py_EnterRecursiveCall(where string) int {
 	cwhere := C.CString(where)
-	C.free(unsafe.Pointer(cwhere))
+	defer C.free(unsafe.Pointer(cwhere))
 
 	return int(C._go_Py_EnterRecursiveCall(cwhere))
 }


### PR DESCRIPTION
### What does this PR do?

Add `defer` before `C.free` in `Py_EnterRecursiveCall`.

### Motivation

Fix the memory error may happen.

### Additional Notes

None.

