### PR TITLE
Fix PyModule_GetState

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 templates:
   job_template: &job_template
-    working_directory: /go/src/github.com/DataDog/go-python3
+    working_directory: /go/src/github.com/go-python/cpy3
     docker:
       - image: golang:1.11.2
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 vendor
+
+# IDE config
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
-Please, open issues and submit PRs on https://github.com/DataDog/go-python3 using the provided templates.
+Please, open issues and submit PRs on https://github.com/go-python/cpy3 using the provided templates.
+
+Backward compatibility is a priority. Please, avoid introducing breaking changes. (Exceptions need a good reason).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
-Copyright (c) 2018 Datadog, Inc.
+Copyright (c) 2018 - 2021 Datadog, Inc.
+Copyright (c) 2018 - 2021 Contributors to the DataDog/go-python3 project
+Copyright (c) 2021 Contributors to the go-python/cpy3 project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-**This repo will be archived on December 1st 2021. While still readable it will no longer be maintained.**
-
-# go-python3
+# Go bindings for the CPython-3 C-API
 
 **Currently supports python-3.7 only.**
-
-Golang bindings for the C-API of CPython-3.
 
 This package provides a ``go`` package named "python" under which most of the
 ``PyXYZ`` functions and macros of the public C-API of CPython have been
 exposed. Theoretically, you should be able use https://docs.python.org/3/c-api
 and know what to type in your ``go`` program.
 
+## relation to `DataDog/go-python3`
 
-This project was inspired by https://github.com/sbinet/go-python. Go and take a look if we need something for python-2.7!
+This project is a community maintained successor to [`DataDog/go-python3`](https://github.com/DataDog/go-python3), which will get archived in December 2021.
+
+- If you use the Go package `github.com/DataDog/go-python3` in your code, you can use `github.com/go-python/cpy3` as a drop-in replacement. We intend to not introduce breaking changes.
+- If you have unmerged PRs or open issues on `DataDog/go-python3`, please re-submit them here.
+
+## relation to `sbinet/go-python`
+
+This project was inspired by [`sbinet/go-python`](https://github.com/sbinet/go-python) (Go bindings for the CPython-2 C-API).
 
 # Install
 
@@ -28,7 +32,7 @@ the `PKG_CONFIG_PATH` environment variable.
 
 ## Go get
 
-Then simply `go get github.com/DataDog/go-python3`
+Then simply `go get github.com/go-python/cpy3`
 
 # API
 
@@ -47,4 +51,9 @@ and error will be set if we failed to open `filename`.
 
 If an error is raise before calling th CPython function `int` default to `-1`.
 
-Take a look at some [examples](examples)
+Take a look at some [examples](examples) and this [tutorial blogpost](https://poweruser.blog/embedding-python-in-go-338c0399f3d5).
+
+# Contributing
+
+Contributions are welcome! See [details](CONTRIBUTING.md).  
+This project follows the [Go Community Code of Conduct](https://golang.org/conduct).

--- a/README.md
+++ b/README.md
@@ -56,4 +56,9 @@ Take a look at some [examples](examples) and this [tutorial blogpost](https://po
 # Contributing
 
 Contributions are welcome! See [details](CONTRIBUTING.md).  
+
+
+# Community
+Find us in [`#go-python`](https://gophers.slack.com/archives/C4FDJLLET) on [Gophers Slack](https://gophers.slack.com). ([infos](https://blog.gopheracademy.com/gophers-slack-community/) | [invite](https://invite.slack.golangbridge.org/))  
+  
 This project follows the [Go Community Code of Conduct](https://golang.org/conduct).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repo will be archived on December 1st 2021. While still readable it will no longer be maintained.**
+
 # go-python3
 
 **Currently supports python-3.7 only.**

--- a/examples/list/main.go
+++ b/examples/list/main.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/go-python3"
+	python3 "github.com/go-python/cpy3"
 )
 
 func main() {

--- a/examples/python3/main.go
+++ b/examples/python3/main.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/go-python3"
+	python3 "github.com/go-python/cpy3"
 )
 
 func main() {

--- a/module.go
+++ b/module.go
@@ -58,7 +58,7 @@ func PyModule_GetName(module *PyObject) string {
 
 //PyModule_GetState : https://docs.python.org/3/c-api/module.html#c.PyModule_GetState
 func PyModule_GetState(module *PyObject) unsafe.Pointer {
-	return unsafe.Pointer(C.PyModule_GetNameObject(toc(module)))
+	return unsafe.Pointer(C.PyModule_GetState(toc(module)))
 }
 
 //PyModule_GetFilenameObject : https://docs.python.org/3/c-api/module.html#c.PyModule_GetFilenameObject

--- a/module_test.go
+++ b/module_test.go
@@ -93,7 +93,7 @@ func TestModuleGetState(t *testing.T) {
 	defer sys.DecRef()
 
 	state := PyModule_GetState(sys)
-	assert.NotNil(t, state)
+	assert.True(t, state == nil)
 }
 
 func TestModuleGetFilenameObject(t *testing.T) {

--- a/script/variadic.go
+++ b/script/variadic.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	python "github.com/DataDog/go-python3"
+	python "github.com/go-python/cpy3"
 )
 
 var (


### PR DESCRIPTION
### What does this PR do?

Fix `PyModule_GetState`.

### Motivation

This should be `C.PyModule_GetState`, not `C.PyModule_GetNameObject`.

In the test, `assert.NotNil` don' t support `unsafe.Pointer(nil)`. It will pass the assert.

### Additional Notes

`PyModuleDef.m_size` is -1 in many modules. They will return nil after calling `PyModule_GetState`.

