### PR TITLE
add link to community fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**This repo will be archived on December 1st 2021. While still readable it will no longer be maintained.**
+**This repo will be archived on December 1st 2021. While still readable it will no longer be maintained.** There's a community maintained successor of this project at https://github.com/go-python/cpy3 .
 
 # go-python3
 


### PR DESCRIPTION
### What does this PR do?

Add a link to the community maintained fork of this project that we're starting at https://github.com/go-python/cpy3.

### Motivation

This is related to the discussion [here](https://github.com/DataDog/go-python3/pull/51#issuecomment-947843296).

### Additional Notes

I'm open to any wording for adding the link - this is just a suggestion.
